### PR TITLE
Add nav bar 1/3: update default.html

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -19,10 +19,12 @@
             <a id="forkme_banner" href="{{ site.github.repository_url }}">View on GitHub</a>
           {% endif %}
 
-          <span>
-              <img class="header_logo" src="{{ '/assets/images/logo.svg' | relative_url }}">
-              <h2 id="project_tagline" style='display:inline;'>{{ site.description | default: site.github.project_tagline }}</h2>
-          </span>
+          <a href="{{ site.baseurl }}/"
+            <span>
+                <img class="header_logo" src="{{ '/assets/images/logo.svg' | relative_url }}">
+                <h2 id="project_tagline" style='display:inline;'>{{ site.description | default: site.github.project_tagline }}</h2>
+            </span>
+          </a>
 
           {% if site.show_downloads %}
             <section id="downloads">
@@ -35,9 +37,18 @@
 
     <!-- MAIN CONTENT -->
     <div id="main_content_wrap" class="outer">
-      <section id="main_content" class="inner">
-        {{ content }}
-      </section>
+      <div id="side_nav_wrap" class="inner"> 
+        <nav id="side_nav" class="inner">
+          {% include toc.md %}    
+        </nav>
+      </div>
+      <div id="page_content_wrap" class="inner">
+        <section id="page_content" class="inner">
+          {{ content }}
+        </section>
+      </div>
+      <div id="filler" class="inner">
+      </div>
     </div>
 
     <!-- FOOTER  -->


### PR DESCRIPTION
This is 1/3 pull requests that, if merged, will give the F' site a nav bar, as shown here: https://chr1st1ansears.github.io/fprime/

This PR specifically updates default.html. It creates the nav bar and places it in a container. It renames main_content to page_content, to avoid confusion, and adds another container for that content, to help with spacing. It adds a filler div, which also helps with the spacing. Lastly, this PR makes the logo and tagline in the banner clickable, so users can click them to get back to the home page.