### PR TITLE
Add nav bar 2/3: update fprime-theme.scss

### DIFF
--- a/_sass/fprime-theme.scss
+++ b/_sass/fprime-theme.scss
@@ -128,6 +128,10 @@ footer a {
   text-decoration: underline;
 }
 
+#side_nav a {
+  color: #F2F2F2;
+}
+
 em, cite {
   font-style: italic;
 }
@@ -374,10 +378,43 @@ Full-Width Styles
   background: #f2f2f2;
   border-top: 1px solid #111;
   border-bottom: 1px solid #111;
+  display: flex;
+  align-items: flex start;
+  }
+
+#side_nav_wrap {
+  padding: 40px 5px;
+  flex-shrink: 4;
+  width: 258px;
 }
 
-#main_content {
-  padding-top: 40px;
+#side_nav {
+  color: $fp-brightorange;
+  background: $fp-darkblue;
+  border-radius: 25px;
+  width: -webkit-fit-content;
+  width: -moz-fit-content;
+  width: fit-content;
+  height: auto;
+  top: 0;
+  margin-left: 0;
+  position:sticky;
+}
+
+#page_content_wrap {
+  flex-grow: 1;
+  flex-shrink: 1;
+  max-width: none;
+  padding: 50px 0px;
+}
+
+#page_content {
+  padding-top: 0px;  
+}
+
+#filler {
+  width: 258px;
+  flex-shrink: 10;
 }
 
 #footer_wrap {
@@ -442,6 +479,29 @@ Small Device Styles
     font-size: 11px;
   }
 
+   #main_content_wrap {
+    flex-wrap: wrap;
+  }
+
+  #side_nav_wrap {
+    padding-right: 25px;
+    padding-bottom: 0px;
+  }
+  
+  #side_nav {
+    width: 100%;
+  }
+
+  #page_content_wrap {
+    padding-top: 20px;
+    padding-bottom: 0px;
+  }
+  
+  #filler {
+    height: 0px;
+    padding: 0px;
+  }
+  
 }
 
 @media screen and (max-width: 320px) {
@@ -492,4 +552,27 @@ Small Device Styles
     font-size: 11px;
   }
 
+  #main_content_wrap {
+    flex-wrap: wrap;
+  }
+
+  #side_nav_wrap {
+    padding-right: 25px;
+    padding-bottom: 0px;
+  }
+  
+  #side_nav {
+    width: 100%;
+  }
+
+  #page_content_wrap {
+    padding-top: 20px;
+    padding-bottom: 0px;
+  }
+  
+  #filler {
+    height: 0px;
+    padding: 0px;
+  }
+    
 }


### PR DESCRIPTION
This is 2/3 pull requests that, if merged, will add a nav bar to the F' docs set, like the one shown here: https://chr1st1ansears.github.io/fprime/

This pull request adds styles for all the new elements in default.html, including the nav bar itself and its wrapper, the page_content (formerly main_content) and its wrapper, and the filler div. It uses flex containers/items to make the nav bar and the whole page responsive. And it includes conditional styling to handle smaller screens.